### PR TITLE
Allow jitpack to deploy the source jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,22 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+    <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+    </plugins>
+  </build>
     <profiles>
         <profile>
             <id>release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -76,38 +76,26 @@
         </dependency>
     </dependencies>
     <build>
-    <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-    </plugins>
-  </build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <id>release</id>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
When consuming non-released versions of the library using Jitpack, it is useful to have the source jar downloadable so we can debug through the library.

Because currently the maven-source-plugin only gets run during release, Jitpack can't generate the source jar for Jitpack's non-release builds.

This changes allows Jitpack to create and deploy the source Jar and allow users to use IDEs to debug through Jitpack deployed vertx-jooq dependency.

For example, to configure a project to consume vertx-jooq through Jitpack, add this under the pom.xml `<project>` tag:

```
<repositories>
	<repository>
	    <id>jitpack.io</id>
	    <url>https://jitpack.io</url>
	</repository>
</repositories>
	
<pluginRepositories>
	<pluginRepository>
		<id>jitpack.io</id>
		<url>https://jitpack.io</url>
	</pluginRepository>
</pluginRepositories>
```

then change the version in the vertx-jooq dependency to a commit hash, for example: `<version>fd34d8ee7b</version>`