### PR TITLE
Changed the enum part of `fromJson` to not use `ofValue`

### DIFF
--- a/vertx-jooq-generate/src/main/java/io/github/jklingsporn/vertx/jooq/generate/AbstractVertxGenerator.java
+++ b/vertx-jooq-generate/src/main/java/io/github/jklingsporn/vertx/jooq/generate/AbstractVertxGenerator.java
@@ -141,7 +141,8 @@ public abstract class AbstractVertxGenerator extends JavaGenerator {
             }else if(isType(columnType,Instant.class)){
                 out.tab(2).println("%s(json.getInstant(\"%s\"));", setter, javaMemberName);
             }else if(table.getDatabase().getEnum(table.getSchema(), column.getType().getUserType()) != null) {
-                out.tab(2).println("%s(Enum.valueOf(%s.class,json.getString(\"%s\")));", setter, columnType, javaMemberName);
+                out.tab(2).println("final io.vertx.core.json.JsonObject finalJson = json;");
+				out.tab(2).println("%s(java.util.Arrays.stream(%s.values()).filter(td -> td.getLiteral().equals(finalJson.getString(\"%s\"))).findFirst().orElse(null));", setter, columnType, javaMemberName);
             }else if(column.getType().getConverter() != null && (isType(column.getType().getConverter(),JsonObjectConverter.class) || isType(column.getType().getConverter(),JsonArrayConverter.class))) {
                 out.tab(2).println("%s(new %s().from(json.getString(\"%s\")));", setter, column.getType().getConverter(), javaMemberName);
             }else{


### PR DESCRIPTION
The suggested code puts all of the valid enums into a stream. Then it filters them to keep only the one that it's literal matches the `javaMemberName`. If no match is found then null is set.