### PR TITLE
Add OffsetDateTime and Instant converters

### DIFF
--- a/vertx-jooq-shared-async/src/main/java/io/github/jklingsporn/vertx/jooq/shared/async/AbstractAsyncQueryExecutor.java
+++ b/vertx-jooq-shared-async/src/main/java/io/github/jklingsporn/vertx/jooq/shared/async/AbstractAsyncQueryExecutor.java
@@ -93,6 +93,24 @@ public abstract class AbstractAsyncQueryExecutor<FIND_MANY_JSON, FIND_ONE_JSON, 
         }else if(object instanceof ZonedDateTime){
             ZonedDateTime convert = (ZonedDateTime) object;
             return new org.joda.time.DateTime(convert.getYear(),convert.getMonthValue(),convert.getDayOfMonth(),convert.getHour(),convert.getMinute(),convert.getSecond(), convert.get(ChronoField.MILLI_OF_SECOND), DateTimeZone.forID(convert.getZone().getId()));
+        } else if (object instanceof OffsetDateTime) {
+            OffsetDateTime obj = (OffsetDateTime) object;
+
+            // Keep the same instant when converting to date time
+            ZonedDateTime convert = obj.atZoneSameInstant(ZoneOffset.UTC);
+            org.joda.time.DateTime dt = new org.joda.time.DateTime(convert.getYear(),
+                    convert.getMonthValue(),
+                    convert.getDayOfMonth(),
+                    convert.getHour(),
+                    convert.getMinute(),
+                    convert.getSecond(),
+                    convert.get(ChronoField.MILLI_OF_SECOND),
+                    DateTimeZone.forID(convert.getZone().getId()));
+            return dt;
+        } else if (object instanceof Instant) {
+            Instant convert = (Instant) object;
+            org.joda.time.Instant i = org.joda.time.Instant.parse(convert.toString());
+            return i.toDateTime();
         }
         return object;
     }


### PR DESCRIPTION
I wanted all my `TIMESTAMP_WITH_TIMEZONE` columns to be `Instants` rather than `OffsetDateTimes` (I presume `OffsetDateTime` is default for the type `TIMESTAMP_WITH_TIMEZONE` in postgres). So I created a converter of the type `Converter<OffsetDateTime, Instant>` that converted `TIMESTAMP_WITH_TIMEZONE` types to Instants. I.e. `OffsetDateTimes` to `Instants`.

However, this resulted in a `ClassCastException: String cannot be converted to OffsetDateTime` stemming from the `converter.from(OffsetDateTime)` method in [AbstractAsyncQueryExecutor](https://github.com/jklingsporn/vertx-jooq/blob/bb6b5fccbadf52fdb168e2d4d719b0fd742b14c3/vertx-jooq-shared-async/src/main/java/io/github/jklingsporn/vertx/jooq/shared/async/AbstractAsyncQueryExecutor.java#L47).

It was trying to force a string type into the `from` method of my converter, where it should have been an `OffsetDateTime`.

This PR fixes that problem by introducing bindings to the `OffsetDateTime` and `Instant` types and so therefore allows `OffsetDateTime` and `Instant` types to be retrieved from databases.

Thanks 👍 