### PR TITLE
Fix number of parameters when using condition contains

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
     <groupId>io.github.jklingsporn</groupId>
-    <version>3.0.1</version>
+    <version>3.0.2-SNAPSHOT</version>
     <artifactId>vertx-jooq</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A jOOQ-CodeGenerator to create vertxified DAOs and POJOs</description>

--- a/vertx-jooq-classic-async/pom.xml
+++ b/vertx-jooq-classic-async/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>3.0.1</version>
+        <version>3.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/vertx-jooq-classic-jdbc/pom.xml
+++ b/vertx-jooq-classic-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>3.0.1</version>
+        <version>3.0.2-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <modelVersion>4.0.0</modelVersion>

--- a/vertx-jooq-classic/pom.xml
+++ b/vertx-jooq-classic/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>3.0.1</version>
+        <version>3.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/vertx-jooq-completablefuture-async/pom.xml
+++ b/vertx-jooq-completablefuture-async/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>3.0.1</version>
+        <version>3.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/vertx-jooq-completablefuture-jdbc/pom.xml
+++ b/vertx-jooq-completablefuture-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>3.0.1</version>
+        <version>3.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/vertx-jooq-completablefuture/pom.xml
+++ b/vertx-jooq-completablefuture/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>3.0.1</version>
+        <version>3.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/vertx-jooq-generate/pom.xml
+++ b/vertx-jooq-generate/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>3.0.1</version>
+        <version>3.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/vertx-jooq-rx-async/pom.xml
+++ b/vertx-jooq-rx-async/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>3.0.1</version>
+        <version>3.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/vertx-jooq-rx-jdbc/pom.xml
+++ b/vertx-jooq-rx-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>3.0.1</version>
+        <version>3.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/vertx-jooq-rx/pom.xml
+++ b/vertx-jooq-rx/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>3.0.1</version>
+        <version>3.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/vertx-jooq-shared-async/pom.xml
+++ b/vertx-jooq-shared-async/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>3.0.1</version>
+        <version>3.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-jooq-shared-async/src/main/java/io/github/jklingsporn/vertx/jooq/shared/async/AbstractAsyncQueryExecutor.java
+++ b/vertx-jooq-shared-async/src/main/java/io/github/jklingsporn/vertx/jooq/shared/async/AbstractAsyncQueryExecutor.java
@@ -56,8 +56,10 @@ public abstract class AbstractAsyncQueryExecutor<FIND_MANY_JSON, FIND_ONE_JSON, 
     protected JsonArray getBindValues(Query query) {
         ArrayList<Object> bindValues = new ArrayList<>();
         for (Param<?> param : query.getParams().values()) {
-            Object value = convertToDatabaseType(param);
-            bindValues.add(value);
+            if(!param.getParamType().equals(ParamType.INLINED)) {
+                Object value = convertToDatabaseType(param);
+                bindValues.add(value);
+            }
         }
         return new JsonArray(bindValues);
     }

--- a/vertx-jooq-shared/pom.xml
+++ b/vertx-jooq-shared/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>3.0.1</version>
+        <version>3.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>


### PR DESCRIPTION
Hi, when i want to use JooQ condition `contains` with one of my DAO, an exception is raised. I'm using async driver.
```
2018-03-06 10:27:34.661 [vert.x-eventloop-thread-1] DEBUG io.github.jklingsporn.vertx.jooq.shared.async.AbstractAsyncQueryExecutor - Executing select `tpe_cp`.`subscription`.`uid`, `tpe_cp`.`subscription`.`customer_uid`, `tpe_cp`.`subscription`.`external_id`, `tpe_cp`.`subscription`.`name`, `tpe_cp`.`subscription`.`data`, `tpe_cp`.`subscription`.`creation_date`, `tpe_cp`.`subscription`.`installation_id`, `tpe_cp`.`subscription`.`offer_id`, `tpe_cp`.`subscription`.`subscription_date`, `tpe_cp`.`subscription`.`engagement_period`, `tpe_cp`.`subscription`.`expiration_date` from `tpe_cp`.`subscription` where (`tpe_cp`.`subscription`.`customer_uid` = 1 and (lower(`tpe_cp`.`subscription`.`external_id`) like lower(concat('%', 'test', '%')) escape '!' or lower(`tpe_cp`.`subscription`.`name`) like lower(concat('%', 'test', '%')) escape '!' or lower(`tpe_cp`.`subscription`.`installation_id`) like lower(concat('%', 'test', '%')) escape '!'))
2018-03-06 10:27:34.664 [vert.x-eventloop-thread-1] ERROR com.actility.thingpark.enterprise.channel.portal.controller.ControllerErrorHandler - Unexpected exception was raised
com.github.mauricio.async.db.exceptions.InsufficientParametersException: The query contains 4 parameters but you gave it 13 (1,%,test,%,!,%,test,%,!,%,test,%,!)
	at com.github.mauricio.async.db.mysql.MySQLConnection.sendPreparedStatement(MySQLConnection.scala:237) ~[mysql-async_2.12-0.2.21.jar:0.2.21]
	at io.vertx.ext.asyncsql.impl.AsyncSQLConnectionImpl.lambda$queryWithParams$4(AsyncSQLConnectionImpl.java:132) ~[vertx-mysql-postgresql-client-3.5.1.jar:3.5.1]
	at io.vertx.ext.asyncsql.impl.AsyncSQLConnectionImpl.beginTransactionIfNeeded(AsyncSQLConnectionImpl.java:298) ~[vertx-mysql-postgresql-client-3.5.1.jar:3.5.1]
	at io.vertx.ext.asyncsql.impl.AsyncSQLConnectionImpl.queryWithParams(AsyncSQLConnectionImpl.java:131) ~[vertx-mysql-postgresql-client-3.5.1.jar:3.5.1]
	at io.github.jklingsporn.vertx.jooq.classic.async.AsyncClassicGenericQueryExecutor.lambda$findManyJson$1(AsyncClassicGenericQueryExecutor.java:53) ~[vertx-jooq-classic-async-3.0.1.jar:?]
	at io.vertx.core.Future.lambda$compose$1(Future.java:265) ~[vertx-core-3.5.1.jar:3.5.1]
	at io.vertx.core.impl.FutureImpl.tryComplete(FutureImpl.java:121) ~[vertx-core-3.5.1.jar:3.5.1]
	at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:83) ~[vertx-core-3.5.1.jar:3.5.1]
	at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:147) ~[vertx-core-3.5.1.jar:3.5.1]
	at io.vertx.core.impl.FutureImpl.handle(FutureImpl.java:18) ~[vertx-core-3.5.1.jar:3.5.1]
	at io.vertx.ext.asyncsql.impl.BaseSQLClient.lambda$getConnection$0(BaseSQLClient.java:72) ~[vertx-mysql-postgresql-client-3.5.1.jar:3.5.1]
	at io.vertx.ext.asyncsql.impl.pool.AsyncConnectionPool.lambda$createConnection$0(AsyncConnectionPool.java:69) ~[vertx-mysql-postgresql-client-3.5.1.jar:3.5.1]
	at io.vertx.ext.asyncsql.impl.ScalaUtils$3.apply(ScalaUtils.java:91) ~[vertx-mysql-postgresql-client-3.5.1.jar:3.5.1]
	at io.vertx.ext.asyncsql.impl.ScalaUtils$3.apply(ScalaUtils.java:87) ~[vertx-mysql-postgresql-client-3.5.1.jar:3.5.1]
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:60) ~[scala-library-2.12.4.jar:?]
	at io.vertx.ext.asyncsql.impl.VertxEventLoopExecutionContext.lambda$execute$0(VertxEventLoopExecutionContext.java:59) ~[vertx-mysql-postgresql-client-3.5.1.jar:3.5.1]
	at io.vertx.core.impl.ContextImpl.lambda$wrapTask$2(ContextImpl.java:339) ~[vertx-core-3.5.1.jar:3.5.1]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163) [netty-common-4.1.19.Final.jar:4.1.19.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404) [netty-common-4.1.19.Final.jar:4.1.19.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:463) [netty-transport-4.1.19.Final.jar:4.1.19.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:886) [netty-common-4.1.19.Final.jar:4.1.19.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.19.Final.jar:4.1.19.Final]
	at java.lang.Thread.run(Thread.java:745) [?:1.8.0_92]
```
I fixed this issue by ignoring params of type `INLINED` in the `getBindValues` method.