### PR TITLE
Only cast to JSON for PostgreSQL to allow MySQL compatibility

### DIFF
--- a/vertx-jooq-generate/src/main/java/io/github/jklingsporn/vertx/jooq/generate/VertxGenerator.java
+++ b/vertx-jooq-generate/src/main/java/io/github/jklingsporn/vertx/jooq/generate/VertxGenerator.java
@@ -3,7 +3,7 @@ package io.github.jklingsporn.vertx.jooq.generate;
 import io.github.jklingsporn.vertx.jooq.shared.JsonArrayConverter;
 import io.github.jklingsporn.vertx.jooq.shared.JsonObjectConverter;
 import io.github.jklingsporn.vertx.jooq.shared.internal.AbstractVertxDAO;
-import io.github.jklingsporn.vertx.jooq.shared.postgres.ObjectToJsonObjectBinding;
+import io.github.jklingsporn.vertx.jooq.shared.ObjectToJsonObjectBinding;
 import io.vertx.core.Vertx;
 import io.vertx.core.impl.Arguments;
 import org.jooq.Constants;

--- a/vertx-jooq-generate/src/main/java/io/github/jklingsporn/vertx/jooq/generate/builder/VertxGeneratorBuilder.java
+++ b/vertx-jooq-generate/src/main/java/io/github/jklingsporn/vertx/jooq/generate/builder/VertxGeneratorBuilder.java
@@ -3,7 +3,7 @@ package io.github.jklingsporn.vertx.jooq.generate.builder;
 import io.github.jklingsporn.vertx.jooq.shared.JsonArrayConverter;
 import io.github.jklingsporn.vertx.jooq.shared.JsonObjectConverter;
 import io.github.jklingsporn.vertx.jooq.shared.internal.AbstractVertxDAO;
-import io.github.jklingsporn.vertx.jooq.shared.postgres.ObjectToJsonObjectBinding;
+import io.github.jklingsporn.vertx.jooq.shared.ObjectToJsonObjectBinding;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;

--- a/vertx-jooq-shared/src/main/java/io/github/jklingsporn/vertx/jooq/shared/ObjectToJsonArrayBinding.java
+++ b/vertx-jooq-shared/src/main/java/io/github/jklingsporn/vertx/jooq/shared/ObjectToJsonArrayBinding.java
@@ -1,4 +1,4 @@
-package io.github.jklingsporn.vertx.jooq.shared.postgres;
+package io.github.jklingsporn.vertx.jooq.shared;
 
 import io.vertx.core.json.JsonArray;
 import org.jooq.*;
@@ -12,7 +12,7 @@ import java.util.Objects;
 /**
  * @author jensklingsporn
  */
-public class ObjectToJsonArrayBinding implements Binding<Object, JsonArray>{
+public class ObjectToJsonArrayBinding implements Binding<Object, JsonArray> {
 
     private static final Converter<Object, JsonArray> CONVERTER = new Converter<Object, JsonArray>() {
         @Override
@@ -44,11 +44,15 @@ public class ObjectToJsonArrayBinding implements Binding<Object, JsonArray>{
 
     // Rending a bind variable for the binding context's value and casting it to the json type
     @Override
-    public void sql(BindingSQLContext<JsonArray> ctx) throws SQLException {
+    public void sql(BindingSQLContext<JsonArray> ctx) {
         // Depending on how you generate your SQL, you may need to explicitly distinguish
         // between jOOQ generating bind variables or inlined literals. If so, use this check:
         // ctx.render().paramType() == INLINED
-        ctx.render().visit(DSL.val(ctx.convert(converter()).value())).sql("::json");
+        RenderContext context = ctx.render().visit(DSL.val(ctx.convert(converter()).value()));
+        if (ctx.configuration().dialect() == SQLDialect.POSTGRES)
+        {
+            context.sql("::json");
+        }
     }
 
     // Registering VARCHAR types for JDBC CallableStatement OUT parameters

--- a/vertx-jooq-shared/src/main/java/io/github/jklingsporn/vertx/jooq/shared/ObjectToJsonObjectBinding.java
+++ b/vertx-jooq-shared/src/main/java/io/github/jklingsporn/vertx/jooq/shared/ObjectToJsonObjectBinding.java
@@ -1,4 +1,4 @@
-package io.github.jklingsporn.vertx.jooq.shared.postgres;
+package io.github.jklingsporn.vertx.jooq.shared;
 
 import io.vertx.core.json.JsonObject;
 import org.jooq.*;
@@ -12,7 +12,7 @@ import java.util.Objects;
 /**
  * @author jensklingsporn
  */
-public class ObjectToJsonObjectBinding implements Binding<Object, JsonObject>{
+public class ObjectToJsonObjectBinding implements Binding<Object, JsonObject> {
 
     private static final Converter<Object, JsonObject> CONVERTER = new Converter<Object, JsonObject>() {
         @Override
@@ -44,11 +44,15 @@ public class ObjectToJsonObjectBinding implements Binding<Object, JsonObject>{
 
     // Rending a bind variable for the binding context's value and casting it to the json type
     @Override
-    public void sql(BindingSQLContext<JsonObject> ctx) throws SQLException {
+    public void sql(BindingSQLContext<JsonObject> ctx) {
         // Depending on how you generate your SQL, you may need to explicitly distinguish
         // between jOOQ generating bind variables or inlined literals. If so, use this check:
         // ctx.render().paramType() == INLINED
-        ctx.render().visit(DSL.val(ctx.convert(converter()).value())).sql("::json");
+        RenderContext context = ctx.render().visit(DSL.val(ctx.convert(converter()).value()));
+        if (ctx.configuration().dialect() == SQLDialect.POSTGRES)
+        {
+            context.sql("::json");
+        }
     }
 
     // Registering VARCHAR types for JDBC CallableStatement OUT parameters

--- a/vertx-jooq-shared/src/test/java/io/github/jklingsporn/vertx/jooq/shared/ObjectToJsonObjectBindingTest.java
+++ b/vertx-jooq-shared/src/test/java/io/github/jklingsporn/vertx/jooq/shared/ObjectToJsonObjectBindingTest.java
@@ -1,4 +1,4 @@
-package io.github.jklingsporn.vertx.jooq.shared.postgres;
+package io.github.jklingsporn.vertx.jooq.shared;
 
 import io.vertx.core.json.JsonObject;
 import org.junit.Assert;
@@ -13,13 +13,13 @@ public class ObjectToJsonObjectBindingTest {
 
 
     @Test
-    public void convertFromNullShouldReturnNull() throws Exception {
+    public void convertFromNullShouldReturnNull() {
         JsonObject from = binding.converter().from(null);
         Assert.assertNull(from);
     }
 
     @Test
-    public void convertToNullShouldReturnNull() throws Exception {
+    public void convertToNullShouldReturnNull() {
         Object to = binding.converter().to(null);
         Assert.assertNull(to);
     }


### PR DESCRIPTION
Fixes #79 

I changed the package names to make it clearer that they're no longer postgres specific.