### PR TITLE
Allow `getType()`, like `getTable()`

### DIFF
--- a/vertx-jooq-shared/src/main/java/io/github/jklingsporn/vertx/jooq/shared/internal/AbstractVertxDAO.java
+++ b/vertx-jooq-shared/src/main/java/io/github/jklingsporn/vertx/jooq/shared/internal/AbstractVertxDAO.java
@@ -32,6 +32,10 @@ public abstract class AbstractVertxDAO<R extends UpdatableRecord<R>, P, T, FIND_
         this.queryExecutor = queryExecutor;
     }
 
+    public Class<P> getType() {
+        return type;
+    }
+
     public Table<R> getTable() {
         return table;
     }


### PR DESCRIPTION
Expose the POJO type this DAO manages in case utilities that juggle a lot of DAOs want to check out the POJO that this DAO manages, for reflection or advanced record mapping.

# Justification:

In my application, we're doing a lot of `JOIN` queries, some of them rather complicated, through the `AbstractVertxDAO`'s query executor. In order to make this easier, I've built a set of wrappers over the vertx-jooq and jOOQ APIs to manage such complicated joins - and more importantly: to fetch the results into jOOQ POJOs.

A usage example looks like this:

```
new QueryManager<>(leftDao).with(rightDao).findManyByCondition(
    LEFTS.FIELD.eq(someValue).and(RIGHTS.OTHER.eq(otherValue)))
.thenApply((ResultsCollector res) -> res.into(Lefts.class, Rights.class, (l,r) -> {
     // represent the fact that I've just loaded l and r from a joined QueryResult
     // and do something with them
     addResults(l,r); // ?
}))
```

The `QueryManager` code knows how to create a join query with the correct cross-table references, then  run it using `QueryExecutor.query()` and wrap the resulting `QueryResult` in a `ResultsCollector` instance that knows about all the `AbstractVertxDAO`s that participated in the query. `ResultsCollector` then offers a set of APIs to let the developer extract whatever POJOs they want from the resultset in a variety of ways.

The main problem is that if you have a column with a non-qualified name that conflicts with columns from other tables in the join query, the jOOQ `DefaultRecordMapper` can't handle this and will apply all the values from all columns with the same non-qualified name to that POJO field in all classes.

For example, if the JOIN between `employees` and `departments` results in this table:
```
+----+-------+-------+----+------------+
| id | first | last  | id | department |
+----+-------+-------+----+------------+
|  1 | John  | Smith |  2 | R&D        |
|  3 | Jane  | Roe   |  1 | SRE        |
+----+-------+-------+----+------------+
```
and then you fetch each `Record` from the `QueryResult` and try to do `r.into(Employees.class)` followed by `r.into(Departments.class)`, you'd find that the first employee `id` field was set to `2` and the second employee's `id` field was set to `1`.

What I need to do instead is: for each POJO the user wants from my `ResultsCollector`, locate the relevant DAO and its table, and generate a record with just that table fields and the use the new record (containing only the selected fields) to create the POJO. `Record.into(Table<R>)` knows to select the fields by the qualified column name (including the table name): `r.info(employeeDao.getTable()).into(Employee.class)` - this works well.

The problem is that `ResultsCollector` knows all the DAOs (as a collection of `AbstractVertxDAO`) and needs a way to locate the correct one given the POJO type provided by the user. It is easy if I have access to the `AbstractVertxDAO.type` field, impossible without it and without complicating the API (forcing the user to hint which DAO manages which POJO, even though the DAO already has that information).

So that is why I need this change. If you think there's a way to do this without this PR and while keeping the `QueryManager` API simple, I would love to hear your opinion.
