### PR TITLE
Report field name of incorrect JSON types

### DIFF
--- a/vertx-jooq-generate/src/main/java/io/github/jklingsporn/vertx/jooq/generate/VertxGenerator.java
+++ b/vertx-jooq-generate/src/main/java/io/github/jklingsporn/vertx/jooq/generate/VertxGenerator.java
@@ -249,44 +249,49 @@ public abstract class VertxGenerator extends JavaGenerator {
             String setter = getStrategy().getJavaSetterName(column, GeneratorStrategy.Mode.INTERFACE);
             String columnType = getJavaType(column.getType());
             String javaMemberName = getJsonKeyName(column);
+            out.tab(2).println("try {");            
             if(handleCustomTypeFromJson(column, setter, columnType, javaMemberName, out)) {
                 //handled by user
             }else if(isType(columnType, Integer.class)){
-                out.tab(2).println("%s(json.getInteger(\"%s\"));", setter, javaMemberName);
+                out.tab(3).println("%s(json.getInteger(\"%s\"));", setter, javaMemberName);
             }else if(isType(columnType, Short.class)){
-                out.tab(2).println("%s(json.getInteger(\"%s\")==null?null:json.getInteger(\"%s\").shortValue());", setter, javaMemberName, javaMemberName);
+                out.tab(3).println("%s(json.getInteger(\"%s\")==null?null:json.getInteger(\"%s\").shortValue());", setter, javaMemberName, javaMemberName);
             }else if(isType(columnType, Byte.class)){
-                out.tab(2).println("%s(json.getInteger(\"%s\")==null?null:json.getInteger(\"%s\").byteValue());", setter, javaMemberName, javaMemberName);
+                out.tab(3).println("%s(json.getInteger(\"%s\")==null?null:json.getInteger(\"%s\").byteValue());", setter, javaMemberName, javaMemberName);
             }else if(isType(columnType, Long.class)){
-                out.tab(2).println("%s(json.getLong(\"%s\"));", setter, javaMemberName);
+                out.tab(3).println("%s(json.getLong(\"%s\"));", setter, javaMemberName);
             }else if(isType(columnType, Float.class)){
-                out.tab(2).println("%s(json.getFloat(\"%s\"));", setter, javaMemberName);
+                out.tab(3).println("%s(json.getFloat(\"%s\"));", setter, javaMemberName);
             }else if(isType(columnType, Double.class)){
-                out.tab(2).println("%s(json.getDouble(\"%s\"));", setter, javaMemberName);
+                out.tab(3).println("%s(json.getDouble(\"%s\"));", setter, javaMemberName);
             }else if(isType(columnType, Boolean.class)){
-                out.tab(2).println("%s(json.getBoolean(\"%s\"));", setter, javaMemberName);
+                out.tab(3).println("%s(json.getBoolean(\"%s\"));", setter, javaMemberName);
             }else if(isType(columnType, String.class)){
-                out.tab(2).println("%s(json.getString(\"%s\"));", setter, javaMemberName);
+                out.tab(3).println("%s(json.getString(\"%s\"));", setter, javaMemberName);
             }else if(columnType.equals(byte.class.getName()+"[]")){
-                out.tab(2).println("%s(json.getBinary(\"%s\"));", setter, javaMemberName);
+                out.tab(3).println("%s(json.getBinary(\"%s\"));", setter, javaMemberName);
             }else if(isType(columnType,Instant.class)){
-                out.tab(2).println("%s(json.getInstant(\"%s\"));", setter, javaMemberName);
+                out.tab(3).println("%s(json.getInstant(\"%s\"));", setter, javaMemberName);
             }else if(isEnum(table, column)) {
                 //if enum is handled by custom type, getLiteral() is not available
                 if(column.getType().getConverter() == null){
-                    out.tab(2).println("%s(java.util.Arrays.stream(%s.values()).filter(td -> td.getLiteral().equals(json.getString(\"%s\"))).findFirst().orElse(null));", setter, columnType, javaMemberName);
+                    out.tab(3).println("%s(java.util.Arrays.stream(%s.values()).filter(td -> td.getLiteral().equals(json.getString(\"%s\"))).findFirst().orElse(null));", setter, columnType, javaMemberName);
                 }else{
-                    out.tab(2).println("%s(java.util.Arrays.stream(%s.values()).filter(td -> td.name().equals(json.getString(\"%s\"))).findFirst().orElse(null));", setter, columnType, javaMemberName);
+                    out.tab(3).println("%s(java.util.Arrays.stream(%s.values()).filter(td -> td.name().equals(json.getString(\"%s\"))).findFirst().orElse(null));", setter, columnType, javaMemberName);
                 }
             }else if((column.getType().getConverter() != null && isType(column.getType().getConverter(),JsonObjectConverter.class)) ||
                     (column.getType().getBinding() != null && isType(column.getType().getBinding(),ObjectToJsonObjectBinding.class))){
-                out.tab(2).println("%s(json.getJsonObject(\"%s\"));", setter, javaMemberName);
+                out.tab(3).println("%s(json.getJsonObject(\"%s\"));", setter, javaMemberName);
             }else if(column.getType().getConverter() != null && isType(column.getType().getConverter(),JsonArrayConverter.class)){
-                out.tab(2).println("%s(json.getJsonArray(\"%s\"));", setter, javaMemberName);
+                out.tab(3).println("%s(json.getJsonArray(\"%s\"));", setter, javaMemberName);
             }else{
                 logger.warn(String.format("Omitting unrecognized type %s for column %s in table %s!",columnType,column.getName(),table.getName()));
-                out.tab(2).println(String.format("// Omitting unrecognized type %s for column %s!",columnType,column.getName()));
+                out.tab(3).println(String.format("// Omitting unrecognized type %s for column %s!",columnType,column.getName()));
             }
+            out.tab(2).println("} catch (java.lang.ClassCastException e) {");
+            out.tab(3).println("String msg = e.getMessage().replaceAll(\"\\\\w+\\\\.\",\"\").toLowerCase();");
+            out.tab(3).println("throw new ClassCastException(\"Invalid type for field '\" + %s + \"': \" + msg);");
+            out.tab(2).println("}");
         }
         out.tab(2).println("return this;");
         out.tab(1).println("}");

--- a/vertx-jooq-generate/src/main/java/io/github/jklingsporn/vertx/jooq/generate/VertxGenerator.java
+++ b/vertx-jooq-generate/src/main/java/io/github/jklingsporn/vertx/jooq/generate/VertxGenerator.java
@@ -290,7 +290,7 @@ public abstract class VertxGenerator extends JavaGenerator {
             }
             out.tab(2).println("} catch (java.lang.ClassCastException e) {");
             out.tab(3).println("String msg = e.getMessage().replaceAll(\"\\\\w+\\\\.\",\"\").toLowerCase();");
-            out.tab(3).println("throw new ClassCastException(\"Invalid type for field '\" + %s + \"': \" + msg);");
+            out.tab(3).println("throw new ClassCastException(\"Invalid type for field '\" + %s + \"': \" + msg);", javaMemberName);
             out.tab(2).println("}");
         }
         out.tab(2).println("return this;");

--- a/vertx-jooq-generate/src/main/java/io/github/jklingsporn/vertx/jooq/generate/VertxGenerator.java
+++ b/vertx-jooq-generate/src/main/java/io/github/jklingsporn/vertx/jooq/generate/VertxGenerator.java
@@ -290,7 +290,7 @@ public abstract class VertxGenerator extends JavaGenerator {
             }
             out.tab(2).println("} catch (java.lang.ClassCastException e) {");
             out.tab(3).println("String msg = e.getMessage().replaceAll(\"\\\\w+\\\\.\",\"\").toLowerCase();");
-            out.tab(3).println("throw new ClassCastException(\"Invalid type for field '\" + %s + \"': \" + msg);", javaMemberName);
+            out.tab(3).println("throw new ClassCastException(\"Invalid type for field '%s': \" + msg);", javaMemberName);
             out.tab(2).println("}");
         }
         out.tab(2).println("return this;");

--- a/vertx-jooq-generate/src/main/java/io/github/jklingsporn/vertx/jooq/generate/VertxGenerator.java
+++ b/vertx-jooq-generate/src/main/java/io/github/jklingsporn/vertx/jooq/generate/VertxGenerator.java
@@ -289,7 +289,7 @@ public abstract class VertxGenerator extends JavaGenerator {
                 out.tab(3).println(String.format("// Omitting unrecognized type %s for column %s!",columnType,column.getName()));
             }
             out.tab(2).println("} catch (java.lang.ClassCastException e) {");
-            out.tab(3).println("String msg = e.getMessage().replaceAll(\"\\\\w+\\\\.\",\"\").toLowerCase();");
+            out.tab(3).println("String msg = e.getMessage().replaceAll(\"\\\\w+\\\\.\",\"\").toLowerCase().split(\"(\")[0].trim();");
             out.tab(3).println("throw new ClassCastException(\"Invalid type for field '%s': \" + msg);", javaMemberName);
             out.tab(2).println("}");
         }

--- a/vertx-jooq-generate/src/main/java/io/github/jklingsporn/vertx/jooq/generate/VertxGenerator.java
+++ b/vertx-jooq-generate/src/main/java/io/github/jklingsporn/vertx/jooq/generate/VertxGenerator.java
@@ -288,9 +288,9 @@ public abstract class VertxGenerator extends JavaGenerator {
                 logger.warn(String.format("Omitting unrecognized type %s for column %s in table %s!",columnType,column.getName(),table.getName()));
                 out.tab(3).println(String.format("// Omitting unrecognized type %s for column %s!",columnType,column.getName()));
             }
+            out.ref("io.github.jklingsporn.vertx.jooq.shared.UnexpectedJsonValueType");
             out.tab(2).println("} catch (java.lang.ClassCastException e) {");
-            out.tab(3).println("String msg = e.getMessage().replaceAll(\"\\\\w+\\\\.\",\"\").toLowerCase().split(\"(\")[0].trim();");
-            out.tab(3).println("throw new ClassCastException(\"Invalid type for field '%s': \" + msg);", javaMemberName);
+            out.tab(3).println("throw new UnexpectedJsonValueType(\"%s\",\"%s\",e);", javaMemberName, columnType);
             out.tab(2).println("}");
         }
         out.tab(2).println("return this;");

--- a/vertx-jooq-shared/src/main/java/io/github/jklingsporn/vertx/jooq/shared/UnexpectedJsonValueType.java
+++ b/vertx-jooq-shared/src/main/java/io/github/jklingsporn/vertx/jooq/shared/UnexpectedJsonValueType.java
@@ -1,0 +1,18 @@
+package io.github.jklingsporn.vertx.jooq.shared;
+
+import java.lang.ClassCastException;
+
+/**
+ * A custom exception type that is thrown from JSON converters, instead of {@link java.lang.ClassCastException}
+ * when the expected type is different than the provided type.
+ * @author guss77
+ */
+public class UnexpectedJsonValueType extends ClassCastException {
+  private static final long serialVersionUID = 8727637165178779604L;
+  
+  public UnexpectedJsonValueType(String fieldName, String fieldType, ClassCastException cause) {
+    super("Invalid JSON type provided for field '" + fieldName + "', expecting: " +
+        fieldType.replaceAll("\\w+\\.","").toLowerCase()); // trim field type to something JSON lovers would recognize
+  }
+  
+}

--- a/vertx-jooq-shared/src/main/java/io/github/jklingsporn/vertx/jooq/shared/UnexpectedJsonValueType.java
+++ b/vertx-jooq-shared/src/main/java/io/github/jklingsporn/vertx/jooq/shared/UnexpectedJsonValueType.java
@@ -11,8 +11,18 @@ public class UnexpectedJsonValueType extends ClassCastException {
   private static final long serialVersionUID = 8727637165178779604L;
   
   public UnexpectedJsonValueType(String fieldName, String fieldType, ClassCastException cause) {
-    super("Invalid JSON type provided for field '" + fieldName + "', expecting: " +
-        fieldType.replaceAll("\\w+\\.","").toLowerCase()); // trim field type to something JSON lovers would recognize
+    super("Invalid JSON type provided for field '" + fieldName + "', expecting: " + jsonifyType(fieldType));
+  }
+  
+  /**
+   * Trim field type to something JSON lovers would recognize.
+   * @param type The Java type
+   * @return a not exactly JSON type, but close
+   */
+  private static String jsonifyType(String type) {
+    return type
+      .replaceAll("\\w+\\.","") // remove package
+      .replace("Json",""); // handle Vert.x's Json(Object|Array)
   }
   
 }


### PR DESCRIPTION
With the current `fromJson()` implementation, if the user sends an unexpected type in a JSON field (e.g. send a number for a string field), the Vert.x `JsonObject` implementation will cause a `ClassCastException` to be thrown.

While that exception contains information about the type that failed to convert (both the actual type and the expected type), it doesn't have information about the name of the field that failed, making it harder than necessary to figure out the problem.

This change adds a catch clause to each field getter and handles a `ClassCastException` by throwing a new exception with a message that encodes the field name where the problem occurred as well as a hopefully more friendly format for the type names (without all that Java package stuff).