### PR TITLE
update to new vertx reactive client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </modules>
     <properties>
         <jooq.version>3.11.9</jooq.version>
-        <vertx.version>3.6.3</vertx.version>
+        <vertx.version>3.8.0</vertx.version>
         <hsqldb.version>2.3.2</hsqldb.version>
         <junit.version>4.12</junit.version>
         <guice.version>4.1.0</guice.version>
@@ -36,10 +36,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <postgresql.driver.version>42.2.2</postgresql.driver.version>
-        <reactivepg.client.version>0.11.2</reactivepg.client.version>
     </properties>
     <groupId>io.github.jklingsporn</groupId>
-    <version>4.1.0</version>
+    <version>4.2.0-SNAPSHOT</version>
     <artifactId>vertx-jooq</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A jOOQ-CodeGenerator to create vertxified DAOs and POJOs</description>

--- a/vertx-jooq-classic-async/README.md
+++ b/vertx-jooq-classic-async/README.md
@@ -3,7 +3,7 @@
 <dependency>
   <groupId>io.github.jklingsporn</groupId>
   <artifactId>vertx-jooq-classic-async</artifactId>
-  <version>4.1.0</version>
+  <version>4.2.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -32,7 +32,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
     <dependency>
       <groupId>io.github.jklingsporn</groupId>
       <artifactId>vertx-jooq-classic-async</artifactId>
-      <version>4.1.0</version>
+      <version>4.2.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <build>
@@ -61,7 +61,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
               <dependency>
                   <groupId>io.github.jklingsporn</groupId>
                   <artifactId>vertx-jooq-generate</artifactId>
-                  <version>4.1.0</version>
+                  <version>4.2.0-SNAPSHOT</version>
               </dependency>
           </dependencies>
 
@@ -138,7 +138,7 @@ The following code-snippet can be copy-pasted into your `build.gradle` to genera
 ```gradle
 buildscript {
     ext {
-        vertx_jooq_version = '4.1.0'
+        vertx_jooq_version = '4.2.0-SNAPSHOT'
         postgresql_version = '42.2.2'
     }
     repositories {

--- a/vertx-jooq-classic-async/pom.xml
+++ b/vertx-jooq-classic-async/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>4.1.0</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/vertx-jooq-classic-jdbc/README.md
+++ b/vertx-jooq-classic-jdbc/README.md
@@ -3,7 +3,7 @@
 <dependency>
   <groupId>io.github.jklingsporn</groupId>
   <artifactId>vertx-jooq-classic-jdbc</artifactId>
-  <version>4.1.0</version>
+  <version>4.2.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -32,7 +32,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
     <dependency>
       <groupId>io.github.jklingsporn</groupId>
       <artifactId>vertx-jooq-classic-jdbc</artifactId>
-      <version>4.1.0</version>
+      <version>4.2.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <build>
@@ -61,7 +61,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
               <dependency>
                   <groupId>io.github.jklingsporn</groupId>
                   <artifactId>vertx-jooq-generate</artifactId>
-                  <version>4.1.0</version>
+                  <version>4.2.0-SNAPSHOT</version>
               </dependency>
           </dependencies>
 
@@ -138,7 +138,7 @@ The following code-snippet can be copy-pasted into your `build.gradle` to genera
 ```gradle
 buildscript {
     ext {
-        vertx_jooq_version = '4.1.0'
+        vertx_jooq_version = '4.2.0-SNAPSHOT'
         postgresql_version = '42.2.2'
     }
     repositories {

--- a/vertx-jooq-classic-jdbc/pom.xml
+++ b/vertx-jooq-classic-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>4.1.0</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <modelVersion>4.0.0</modelVersion>

--- a/vertx-jooq-classic-jdbc/src/main/java/io/github/jklingsporn/vertx/jooq/classic/jdbc/JDBCClassicGenericQueryExecutor.java
+++ b/vertx-jooq-classic-jdbc/src/main/java/io/github/jklingsporn/vertx/jooq/classic/jdbc/JDBCClassicGenericQueryExecutor.java
@@ -7,6 +7,7 @@ import io.github.jklingsporn.vertx.jooq.shared.internal.jdbc.JDBCQueryResult;
 import io.github.jklingsporn.vertx.jooq.shared.internal.jdbc.JDBCQueryExecutor;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.jooq.*;
 import org.jooq.impl.DSL;
@@ -30,10 +31,10 @@ public class JDBCClassicGenericQueryExecutor extends AbstractQueryExecutor imple
         return executeBlocking(h -> h.complete(function.apply(DSL.using(configuration()))));
     }
 
-    protected <X> Future<X> executeBlocking(Handler<Future<X>> blockingCodeHandler){
-        Future<X> future = Future.future();
+    protected <X> Future<X> executeBlocking(Handler<Promise<X>> blockingCodeHandler){
+        Promise<X> future = Promise.promise();
         vertx.executeBlocking(blockingCodeHandler,future);
-        return future;
+        return future.future();
     }
 
     @Override

--- a/vertx-jooq-classic-reactive/README.md
+++ b/vertx-jooq-classic-reactive/README.md
@@ -3,7 +3,7 @@
 <dependency>
   <groupId>io.github.jklingsporn</groupId>
   <artifactId>vertx-jooq-classic-reactive</artifactId>
-  <version>4.1.0</version>
+  <version>4.2.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -32,7 +32,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
     <dependency>
       <groupId>io.github.jklingsporn</groupId>
       <artifactId>vertx-jooq-classic-reactive</artifactId>
-      <version>4.1.0</version>
+      <version>4.2.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <build>
@@ -61,7 +61,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
               <dependency>
                   <groupId>io.github.jklingsporn</groupId>
                   <artifactId>vertx-jooq-generate</artifactId>
-                  <version>4.1.0</version>
+                  <version>4.2.0-SNAPSHOT</version>
               </dependency>
           </dependencies>
 
@@ -138,7 +138,7 @@ The following code-snippet can be copy-pasted into your `build.gradle` to genera
 ```gradle
 buildscript {
     ext {
-        vertx_jooq_version = '4.1.0'
+        vertx_jooq_version = '4.2.0-SNAPSHOT'
         postgresql_version = '42.2.2'
     }
     repositories {

--- a/vertx-jooq-classic-reactive/pom.xml
+++ b/vertx-jooq-classic-reactive/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>4.1.0</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-jooq-classic/pom.xml
+++ b/vertx-jooq-classic/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>4.1.0</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/vertx-jooq-completablefuture-async/README.md
+++ b/vertx-jooq-completablefuture-async/README.md
@@ -3,7 +3,7 @@
 <dependency>
   <groupId>io.github.jklingsporn</groupId>
   <artifactId>vertx-jooq-completablefuture-async</artifactId>
-  <version>4.1.0</version>
+  <version>4.2.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -32,7 +32,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
     <dependency>
       <groupId>io.github.jklingsporn</groupId>
       <artifactId>vertx-jooq-completablefuture-async</artifactId>
-      <version>4.1.0</version>
+      <version>4.2.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <build>
@@ -61,7 +61,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
               <dependency>
                   <groupId>io.github.jklingsporn</groupId>
                   <artifactId>vertx-jooq-generate</artifactId>
-                  <version>4.1.0</version>
+                  <version>4.2.0-SNAPSHOT</version>
               </dependency>
           </dependencies>
 
@@ -138,7 +138,7 @@ The following code-snippet can be copy-pasted into your `build.gradle` to genera
 ```gradle
 buildscript {
     ext {
-        vertx_jooq_version = '4.1.0'
+        vertx_jooq_version = '4.2.0-SNAPSHOT'
         postgresql_version = '42.2.2'
     }
     repositories {

--- a/vertx-jooq-completablefuture-async/pom.xml
+++ b/vertx-jooq-completablefuture-async/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>4.1.0</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/vertx-jooq-completablefuture-jdbc/README.md
+++ b/vertx-jooq-completablefuture-jdbc/README.md
@@ -3,7 +3,7 @@
 <dependency>
   <groupId>io.github.jklingsporn</groupId>
   <artifactId>vertx-jooq-completablefuture-jdbc</artifactId>
-  <version>4.1.0</version>
+  <version>4.2.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -32,7 +32,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
     <dependency>
       <groupId>io.github.jklingsporn</groupId>
       <artifactId>vertx-jooq-completablefuture-jdbc</artifactId>
-      <version>4.1.0</version>
+      <version>4.2.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <build>
@@ -61,7 +61,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
               <dependency>
                   <groupId>io.github.jklingsporn</groupId>
                   <artifactId>vertx-jooq-generate</artifactId>
-                  <version>4.1.0</version>
+                  <version>4.2.0-SNAPSHOT</version>
               </dependency>
           </dependencies>
 
@@ -138,7 +138,7 @@ The following code-snippet can be copy-pasted into your `build.gradle` to genera
 ```gradle
 buildscript {
     ext {
-        vertx_jooq_version = '4.1.0'
+        vertx_jooq_version = '4.2.0-SNAPSHOT'
         postgresql_version = '42.2.2'
     }
     repositories {

--- a/vertx-jooq-completablefuture-jdbc/pom.xml
+++ b/vertx-jooq-completablefuture-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>4.1.0</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/vertx-jooq-completablefuture-jdbc/src/main/java/io/github/jklingsporn/vertx/jooq/completablefuture/jdbc/JDBCCompletableFutureGenericQueryExecutor.java
+++ b/vertx-jooq-completablefuture-jdbc/src/main/java/io/github/jklingsporn/vertx/jooq/completablefuture/jdbc/JDBCCompletableFutureGenericQueryExecutor.java
@@ -5,10 +5,7 @@ import io.github.jklingsporn.vertx.jooq.shared.internal.AbstractQueryExecutor;
 import io.github.jklingsporn.vertx.jooq.shared.internal.QueryResult;
 import io.github.jklingsporn.vertx.jooq.shared.internal.jdbc.JDBCQueryResult;
 import io.github.jklingsporn.vertx.jooq.shared.internal.jdbc.JDBCQueryExecutor;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
+import io.vertx.core.*;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 import org.jooq.*;
 import org.jooq.impl.DSL;
@@ -38,7 +35,7 @@ public class JDBCCompletableFutureGenericQueryExecutor extends AbstractQueryExec
      * @param <U>
      * @return a CompletableFuture that is completed when the blocking code has been executed by Vertx.
      */
-    <U> CompletableFuture<U> executeBlocking(Handler<Future<U>> blockingCodeHandler){
+    <U> CompletableFuture<U> executeBlocking(Handler<Promise<U>> blockingCodeHandler){
         VertxCompletableFuture<U> future = new VertxCompletableFuture<>(vertx);
         vertx.executeBlocking(blockingCodeHandler, createCompletionHandler(future));
         return future;

--- a/vertx-jooq-completablefuture-reactive/README.md
+++ b/vertx-jooq-completablefuture-reactive/README.md
@@ -3,7 +3,7 @@
 <dependency>
   <groupId>io.github.jklingsporn</groupId>
   <artifactId>vertx-jooq-completablefuture-reactive</artifactId>
-  <version>4.1.0</version>
+  <version>4.2.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -32,7 +32,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
     <dependency>
       <groupId>io.github.jklingsporn</groupId>
       <artifactId>vertx-jooq-completablefuture-reactive</artifactId>
-      <version>4.1.0</version>
+      <version>4.2.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <build>
@@ -61,7 +61,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
               <dependency>
                   <groupId>io.github.jklingsporn</groupId>
                   <artifactId>vertx-jooq-generate</artifactId>
-                  <version>4.1.0</version>
+                  <version>4.2.0-SNAPSHOT</version>
               </dependency>
           </dependencies>
 
@@ -138,7 +138,7 @@ The following code-snippet can be copy-pasted into your `build.gradle` to genera
 ```gradle
 buildscript {
     ext {
-        vertx_jooq_version = '4.1.0'
+        vertx_jooq_version = '4.2.0-SNAPSHOT'
         postgresql_version = '42.2.2'
     }
     repositories {

--- a/vertx-jooq-completablefuture-reactive/pom.xml
+++ b/vertx-jooq-completablefuture-reactive/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>4.1.0</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-jooq-completablefuture-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/completablefuture/reactivepg/ReactiveCompletableFutureQueryExecutor.java
+++ b/vertx-jooq-completablefuture-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/completablefuture/reactivepg/ReactiveCompletableFutureQueryExecutor.java
@@ -1,11 +1,11 @@
 package io.github.jklingsporn.vertx.jooq.completablefuture.reactivepg;
 
 import io.github.jklingsporn.vertx.jooq.shared.internal.QueryExecutor;
-import io.reactiverse.pgclient.PgClient;
-import io.reactiverse.pgclient.PgRowSet;
-import io.reactiverse.pgclient.PgTransaction;
-import io.reactiverse.pgclient.Row;
 import io.vertx.core.Vertx;
+import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.SqlClient;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.Transaction;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 import org.jooq.*;
 import org.jooq.impl.DefaultConfiguration;
@@ -22,11 +22,11 @@ public class ReactiveCompletableFutureQueryExecutor<R extends UpdatableRecord<R>
 
     private final Function<Row,P> pojoMapper;
 
-    public ReactiveCompletableFutureQueryExecutor(PgClient delegate, Function<Row, P> pojoMapper, Vertx vertx) {
+    public ReactiveCompletableFutureQueryExecutor(SqlClient delegate, Function<Row, P> pojoMapper, Vertx vertx) {
         this(new DefaultConfiguration().set(SQLDialect.POSTGRES),delegate, pojoMapper, vertx);
     }
 
-    public ReactiveCompletableFutureQueryExecutor(Configuration configuration, PgClient delegate, Function<Row, P> pojoMapper, Vertx vertx) {
+    public ReactiveCompletableFutureQueryExecutor(Configuration configuration, SqlClient delegate, Function<Row, P> pojoMapper, Vertx vertx) {
         super(configuration, delegate,vertx);
         this.pojoMapper = pojoMapper;
     }
@@ -45,7 +45,7 @@ public class ReactiveCompletableFutureQueryExecutor<R extends UpdatableRecord<R>
     public CompletableFuture<T> insertReturning(Function<DSLContext, ? extends InsertResultStep<R>> queryFunction, Function<Object, T> keyMapper) {
         Query query = createQuery(queryFunction);
         log(query);
-        CompletableFuture<PgRowSet> rowFuture = new VertxCompletableFuture<>(vertx);
+        CompletableFuture<RowSet> rowFuture = new VertxCompletableFuture<>(vertx);
         delegate.preparedQuery(toPreparedQuery(query),getBindValues(query),createCompletionHandler(rowFuture));
         return rowFuture
                 .thenApply(rows -> rows.iterator().next())
@@ -59,7 +59,7 @@ public class ReactiveCompletableFutureQueryExecutor<R extends UpdatableRecord<R>
     }
 
     @Override
-    protected Function<PgTransaction, ReactiveCompletableFutureQueryExecutor<R,P,T>> newInstance() {
+    protected Function<Transaction, ReactiveCompletableFutureQueryExecutor<R,P,T>> newInstance() {
         return pgTransaction -> new ReactiveCompletableFutureQueryExecutor<R, P, T>(configuration(),pgTransaction,pojoMapper,vertx);
     }
 

--- a/vertx-jooq-completablefuture/README.md
+++ b/vertx-jooq-completablefuture/README.md
@@ -100,7 +100,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
     <dependency>
       <groupId>io.github.jklingsporn</groupId>
       <artifactId>vertx-jooq-future</artifactId>
-      <version>4.1.0</version>
+      <version>4.2.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <build>
@@ -129,7 +129,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
               <dependency>
                   <groupId>io.github.jklingsporn</groupId>
                   <artifactId>vertx-jooq-generate</artifactId>
-                  <version>4.1.0</version>
+                  <version>4.2.0-SNAPSHOT</version>
               </dependency>
           </dependencies>
 

--- a/vertx-jooq-completablefuture/pom.xml
+++ b/vertx-jooq-completablefuture/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>4.1.0</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/vertx-jooq-generate/pom.xml
+++ b/vertx-jooq-generate/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>4.1.0</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/vertx-jooq-rx-async/README.md
+++ b/vertx-jooq-rx-async/README.md
@@ -3,7 +3,7 @@
 <dependency>
   <groupId>io.github.jklingsporn</groupId>
   <artifactId>vertx-jooq-rx-async</artifactId>
-  <version>4.1.0</version>
+  <version>4.2.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -32,7 +32,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
     <dependency>
       <groupId>io.github.jklingsporn</groupId>
       <artifactId>vertx-jooq-rx-async</artifactId>
-      <version>4.1.0</version>
+      <version>4.2.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <build>
@@ -61,7 +61,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
               <dependency>
                   <groupId>io.github.jklingsporn</groupId>
                   <artifactId>vertx-jooq-generate</artifactId>
-                  <version>4.1.0</version>
+                  <version>4.2.0-SNAPSHOT</version>
               </dependency>
           </dependencies>
 
@@ -138,7 +138,7 @@ The following code-snippet can be copy-pasted into your `build.gradle` to genera
 ```gradle
 buildscript {
     ext {
-        vertx_jooq_version = '4.1.0'
+        vertx_jooq_version = '4.2.0-SNAPSHOT'
         postgresql_version = '42.2.2'
     }
     repositories {

--- a/vertx-jooq-rx-async/pom.xml
+++ b/vertx-jooq-rx-async/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>4.1.0</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/vertx-jooq-rx-jdbc/README.md
+++ b/vertx-jooq-rx-jdbc/README.md
@@ -3,7 +3,7 @@
 <dependency>
   <groupId>io.github.jklingsporn</groupId>
   <artifactId>vertx-jooq-rx-jdbc</artifactId>
-  <version>4.1.0</version>
+  <version>4.2.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -32,7 +32,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
     <dependency>
       <groupId>io.github.jklingsporn</groupId>
       <artifactId>vertx-jooq-rx-jdbc</artifactId>
-      <version>4.1.0</version>
+      <version>4.2.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <build>
@@ -61,7 +61,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
               <dependency>
                   <groupId>io.github.jklingsporn</groupId>
                   <artifactId>vertx-jooq-generate</artifactId>
-                  <version>4.1.0</version>
+                  <version>4.2.0-SNAPSHOT</version>
               </dependency>
           </dependencies>
 
@@ -138,7 +138,7 @@ The following code-snippet can be copy-pasted into your `build.gradle` to genera
 ```gradle
 buildscript {
     ext {
-        vertx_jooq_version = '4.1.0'
+        vertx_jooq_version = '4.2.0-SNAPSHOT'
         postgresql_version = '42.2.2'
     }
     repositories {

--- a/vertx-jooq-rx-jdbc/pom.xml
+++ b/vertx-jooq-rx-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>4.1.0</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/vertx-jooq-rx-jdbc/src/main/java/io/github/jklingsporn/vertx/jooq/rx/jdbc/JDBCRXGenericQueryExecutor.java
+++ b/vertx-jooq-rx-jdbc/src/main/java/io/github/jklingsporn/vertx/jooq/rx/jdbc/JDBCRXGenericQueryExecutor.java
@@ -8,6 +8,7 @@ import io.github.jklingsporn.vertx.jooq.shared.internal.jdbc.JDBCQueryExecutor;
 import io.reactivex.Single;
 import io.vertx.core.Handler;
 import io.vertx.reactivex.core.Future;
+import io.vertx.reactivex.core.Promise;
 import io.vertx.reactivex.core.Vertx;
 import org.jooq.*;
 import org.jooq.impl.DSL;
@@ -31,7 +32,7 @@ public class JDBCRXGenericQueryExecutor extends AbstractQueryExecutor implements
         return executeBlocking(h -> h.complete(function.apply(DSL.using(configuration()))));
     }
 
-    <X> Single<X> executeBlocking(Handler<Future<X>> blockingCodeHandler) {
+    <X> Single<X> executeBlocking(Handler<Promise<X>> blockingCodeHandler) {
         return RXTool.executeBlocking(blockingCodeHandler, vertx);
     }
 

--- a/vertx-jooq-rx-jdbc/src/main/java/io/github/jklingsporn/vertx/jooq/rx/jdbc/RXTool.java
+++ b/vertx-jooq-rx-jdbc/src/main/java/io/github/jklingsporn/vertx/jooq/rx/jdbc/RXTool.java
@@ -2,6 +2,7 @@ package io.github.jklingsporn.vertx.jooq.rx.jdbc;
 
 import io.vertx.core.Handler;
 import io.vertx.reactivex.core.Future;
+import io.vertx.reactivex.core.Promise;
 import io.vertx.reactivex.core.Vertx;
 import io.reactivex.Observable;
 import io.reactivex.Single;
@@ -16,12 +17,12 @@ public class RXTool {
     }
 
 
-    public static <T> Single<T> executeBlocking(Handler<Future<T>> blockingCodeHandler, Vertx
+    public static <T> Single<T> executeBlocking(Handler<Promise<T>> blockingCodeHandler, Vertx
         vertx) {
         return vertx.rxExecuteBlocking(blockingCodeHandler).toSingle();
     }
 
-    public static <T> Observable<T> executeBlockingObservable(Handler<Future<List<T>>> blockingCodeHandler, Vertx
+    public static <T> Observable<T> executeBlockingObservable(Handler<Promise<List<T>>> blockingCodeHandler, Vertx
         vertx) {
         return executeBlocking(blockingCodeHandler,vertx)
                 .flatMapObservable(Observable::fromIterable);

--- a/vertx-jooq-rx-reactive/README.md
+++ b/vertx-jooq-rx-reactive/README.md
@@ -3,7 +3,7 @@
 <dependency>
   <groupId>io.github.jklingsporn</groupId>
   <artifactId>vertx-jooq-rx-reactive</artifactId>
-  <version>4.1.0</version>
+  <version>4.2.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -32,7 +32,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
     <dependency>
       <groupId>io.github.jklingsporn</groupId>
       <artifactId>vertx-jooq-rx-reactive</artifactId>
-      <version>4.1.0</version>
+      <version>4.2.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <build>
@@ -61,7 +61,7 @@ If you are new to jOOQ, I recommend to read the awesome [jOOQ documentation](htt
               <dependency>
                   <groupId>io.github.jklingsporn</groupId>
                   <artifactId>vertx-jooq-generate</artifactId>
-                  <version>4.1.0</version>
+                  <version>4.2.0-SNAPSHOT</version>
               </dependency>
           </dependencies>
 
@@ -138,7 +138,7 @@ The following code-snippet can be copy-pasted into your `build.gradle` to genera
 ```gradle
 buildscript {
     ext {
-        vertx_jooq_version = '4.1.0'
+        vertx_jooq_version = '4.2.0-SNAPSHOT'
         postgresql_version = '42.2.2'
     }
     repositories {

--- a/vertx-jooq-rx-reactive/pom.xml
+++ b/vertx-jooq-rx-reactive/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>4.1.0</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-jooq-rx/pom.xml
+++ b/vertx-jooq-rx/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>4.1.0</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/vertx-jooq-shared-async/pom.xml
+++ b/vertx-jooq-shared-async/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>4.1.0</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-jooq-shared-reactive/pom.xml
+++ b/vertx-jooq-shared-reactive/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>4.1.0</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -18,9 +18,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.reactiverse</groupId>
-            <artifactId>reactive-pg-client</artifactId>
-            <version>${reactivepg.client.version}</version>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-sql-client</artifactId>
+            <version>3.8.0</version>
     </dependency>
     </dependencies>
 </project>

--- a/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/AbstractReactiveVertxDAO.java
+++ b/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/AbstractReactiveVertxDAO.java
@@ -3,6 +3,7 @@ package io.github.jklingsporn.vertx.jooq.shared.reactive;
 import io.github.jklingsporn.vertx.jooq.shared.internal.AbstractVertxDAO;
 import io.github.jklingsporn.vertx.jooq.shared.internal.QueryExecutor;
 import io.vertx.core.impl.Arguments;
+import io.vertx.sqlclient.Row;
 import org.jooq.*;
 
 import java.util.function.Function;
@@ -21,14 +22,13 @@ public abstract class AbstractReactiveVertxDAO<R extends UpdatableRecord<R>, P, 
 
     protected AbstractReactiveVertxDAO(Table<R> table, Class<P> type, QueryExecutor<R, T, FIND_MANY, FIND_ONE, EXECUTE, INSERT_RETURNING> queryExecutor) {
         super(table, type, queryExecutor);
-        Arguments.require(SQLDialect.POSTGRES.equals(queryExecutor.configuration().dialect().family()),"Only Postgres supported");
     }
 
     @Override
     @SuppressWarnings("unchecked")
     protected Function<Object,T> keyConverter(){
         return o -> {
-            io.reactiverse.pgclient.Row row = (io.reactiverse.pgclient.Row) o;
+            Row row = (Row) o;
             TableField<R, ?>[] fields = getTable().getPrimaryKey().getFieldsArray();
             if(fields.length == 1){
                 return (T)row.getValue(fields[0].getName());

--- a/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/JsonAccessor.java
+++ b/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/JsonAccessor.java
@@ -1,10 +1,9 @@
 package io.github.jklingsporn.vertx.jooq.shared.reactive;
 
-import io.reactiverse.pgclient.Row;
-import io.reactiverse.pgclient.data.Json;
-import io.reactiverse.pgclient.impl.data.JsonImpl;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.sqlclient.Row;
 
 /**
  * Created by jensklingsporn on 07.08.18.
@@ -13,16 +12,17 @@ public class JsonAccessor {
 
     private JsonAccessor(){}
 
-    public static JsonObject getJsonObject(Row row, String field){
-        return (JsonObject) getJson(row,field).value();
-    }
-
-    public static JsonArray getJsonArray(Row row, String field){
-        return (JsonArray) getJson(row,field).value();
-    }
-
-    public static Json getJson(Row row, String field) {
-        return row.getJson(field) == null ? JsonImpl.NULL : row.getJson(field);
-    }
+//    public static JsonObject getJsonObject(Row row, String field){
+//        return (JsonObject) getJson(row,field).value();
+//    }
+//
+//    public static JsonArray getJsonArray(Row row, String field){
+//        return (JsonArray) getJson(row,field).value();
+//    }
+//
+//    public static Json getJson(Row row, String field) {
+//        //return row.getJson(field) == null ? JsonImpl.NULL : row.getJson(field);
+//        return null;
+//    }
 
 }

--- a/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/ReactiveQueryResult.java
+++ b/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/ReactiveQueryResult.java
@@ -1,8 +1,8 @@
 package io.github.jklingsporn.vertx.jooq.shared.reactive;
 
 import io.github.jklingsporn.vertx.jooq.shared.internal.QueryResult;
-import io.reactiverse.pgclient.PgRowSet;
-import io.reactiverse.pgclient.Row;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
 import org.jooq.Field;
 import org.jooq.tools.Convert;
 
@@ -17,9 +17,9 @@ import java.util.stream.StreamSupport;
 public class ReactiveQueryResult implements QueryResult {
 
     private final Row current;
-    private final PgRowSet result;
+    private final RowSet result;
 
-    public ReactiveQueryResult(PgRowSet result) {
+    public ReactiveQueryResult(RowSet result) {
         this.result = result;
         this.current = result.iterator().next();
     }

--- a/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/UUIDAccessor.java
+++ b/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/UUIDAccessor.java
@@ -1,0 +1,16 @@
+package io.github.jklingsporn.vertx.jooq.shared.reactive;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.sqlclient.Row;
+
+import java.util.UUID;
+
+public class UUIDAccessor {
+    public static UUID getUUID(Row row, String field) {
+        Buffer buffer = row.getBuffer(field);
+        if (buffer == null) {
+            return null;
+        }
+        return new UUID(buffer.getLong(0), buffer.getLong(8));
+    }
+}

--- a/vertx-jooq-shared/pom.xml
+++ b/vertx-jooq-shared/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vertx-jooq</artifactId>
         <groupId>io.github.jklingsporn</groupId>
-        <version>4.1.0</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>


### PR DESCRIPTION
Vertx absorbed the reactive pg client and released one that works with mysql and pg.
New project is at https://github.com/eclipse-vertx/vertx-sql-client ,
release post here https://vertx.io/blog/eclipse-vert-x-3-8-0-released/ 

The interface is basically identical so most of the changes were imports. The project I'm integrating this into uses mysql, so I mostly tested that. I did give postgres a spin and it does work with the types I have, but I didn't test them all. Also I only tested the rx interface (again since these changes were mostly just class renames so everything should be ok, but I don't really have time to test other dbs and interfaces since I'm not using them)

One thing I need help with is updating the vertx-jooq-generate subproject.. I guess it's not required for the rx interface, but I can't find how you regenerate that

Anyway, thanks for the project it's really useful :+1: 