### PR TITLE
Fix JSON and JSONB support for jooq 3.12

### DIFF
--- a/vertx-jooq-generate/src/main/java/io/github/jklingsporn/vertx/jooq/generate/builder/VertxGeneratorBuilder.java
+++ b/vertx-jooq-generate/src/main/java/io/github/jklingsporn/vertx/jooq/generate/builder/VertxGeneratorBuilder.java
@@ -8,6 +8,8 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.jooq.Configuration;
+import org.jooq.JSON;
+import org.jooq.JSONB;
 import org.jooq.codegen.GeneratorStrategy;
 import org.jooq.codegen.JavaWriter;
 import org.jooq.meta.ColumnDefinition;
@@ -341,7 +343,7 @@ public class VertxGeneratorBuilder {
                         }else if(javaType.equals(JsonArray.class.getName())
                                 || (column.getType().getConverter() != null && column.getType().getConverter().equalsIgnoreCase(JsonArrayConverter.class.getName()))){
                             out.tab(3).println("pojo.%s(row.get(io.vertx.core.json.JsonArray.class,row.getColumnIndex(\"%s\")));", setter, column.getName());
-                        }else if(javaTypeInEnumPackage){
+                        }else if(javaTypeInEnumPackage || javaType.equals(JSONB.class.getName()) || javaType.equals(JSON.class.getName())){
                             out.tab(3).println("pojo.%s(%s.valueOf(row.getString(\"%s\")));", setter, javaType, column.getName());
                         }else{
                             ComponentBasedVertxGenerator.logger.warn(String.format("Omitting unrecognized type %s (%s) for column %s in table %s!",column.getType(),javaType,column.getName(),table.getName()));

--- a/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/AbstractReactiveQueryExecutor.java
+++ b/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/AbstractReactiveQueryExecutor.java
@@ -2,14 +2,12 @@ package io.github.jklingsporn.vertx.jooq.shared.reactive;
 
 import io.github.jklingsporn.vertx.jooq.shared.internal.AbstractQueryExecutor;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.impl.ArrayTuple;
-import org.jooq.Configuration;
-import org.jooq.Param;
-import org.jooq.Query;
-import org.jooq.SQLDialect;
+import org.jooq.*;
 import org.jooq.conf.ParamType;
 
 /**
@@ -44,6 +42,18 @@ public abstract class AbstractReactiveQueryExecutor extends AbstractQueryExecuto
          * DataTypes. Workaround is to convert them to string before adding to the Tuple.
          */
         if (Enum.class.isAssignableFrom(param.getBinding().converter().toType())) {
+            return param.getValue().toString();
+        }
+
+        // JSON and JSONB are also not known by vertx-sql-client so, if we get a JsonObject just pass that on,
+        // if we get a JSONB or JSON object convert them to a string.
+        if (JsonObject.class.isAssignableFrom(param.getBinding().converter().toType())) {
+            return param.getValue();
+        }
+        if (JSONB.class.isAssignableFrom(param.getBinding().converter().toType())) {
+            return param.getValue().toString();
+        }
+        if (JSON.class.isAssignableFrom(param.getBinding().converter().toType())) {
             return param.getValue().toString();
         }
         if (byte[].class.isAssignableFrom(param.getBinding().converter().fromType())) { // jooq treats BINARY types as byte[] but the reactive client expects a Buffer to write to blobs

--- a/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/AbstractReactiveQueryExecutor.java
+++ b/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/AbstractReactiveQueryExecutor.java
@@ -30,7 +30,7 @@ public abstract class AbstractReactiveQueryExecutor extends AbstractQueryExecuto
         super(configuration);
     }
 
-    protected Tuple getBindValues(Query query) {
+    public Tuple getBindValues(Query query) {
         ArrayTuple bindValues = new ArrayTuple(query.getParams().size());
         for (Param<?> param : query.getParams().values()) {
             if (!param.isInline()) {
@@ -77,7 +77,7 @@ public abstract class AbstractReactiveQueryExecutor extends AbstractQueryExecuto
         }
     }
 
-    protected String toPreparedQuery(Query query) {
+    public String toPreparedQuery(Query query) {
         if (SQLDialect.POSTGRES.supports(configuration().dialect())) {
             String namedQuery = query.getSQL(ParamType.NAMED);
             return namedQuery.replaceAll(pattern, "\\$");

--- a/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/AbstractReactiveQueryExecutor.java
+++ b/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/AbstractReactiveQueryExecutor.java
@@ -51,13 +51,13 @@ public abstract class AbstractReactiveQueryExecutor extends AbstractQueryExecuto
         }
 
         // JSON and JSONB are also not known by vertx-sql-client so, if we get a JsonObject just pass that on,
-        // if we get a JSONB or JSON object convert them to a string.
+        // if we get a JSONB or JSON object convert them to a JsonObject.
         if (JsonObject.class.isAssignableFrom(param.getBinding().converter().toType())) {
             return param.getValue();
         }
         if (JSONB.class.isAssignableFrom(param.getBinding().converter().fromType()) ||
                 JSON.class.isAssignableFrom(param.getBinding().converter().fromType())) {
-            return param.getBinding().converter().to(param.getValue()).toString();
+            return JsonObject.mapFrom(param.getValue());
         }
         if (byte[].class.isAssignableFrom(param.getBinding().converter().fromType())) { // jooq treats BINARY types as byte[] but the reactive client expects a Buffer to write to blobs
             byte[] bytes = (byte[]) param.getBinding().converter().to(param.getValue());

--- a/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/AbstractReactiveQueryExecutor.java
+++ b/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/AbstractReactiveQueryExecutor.java
@@ -7,7 +7,12 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.impl.ArrayTuple;
-import org.jooq.*;
+import org.jooq.JSON;
+import org.jooq.JSONB;
+import org.jooq.Configuration;
+import org.jooq.Param;
+import org.jooq.Query;
+import org.jooq.SQLDialect;
 import org.jooq.conf.ParamType;
 
 /**

--- a/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/AbstractReactiveQueryExecutor.java
+++ b/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/AbstractReactiveQueryExecutor.java
@@ -55,11 +55,9 @@ public abstract class AbstractReactiveQueryExecutor extends AbstractQueryExecuto
         if (JsonObject.class.isAssignableFrom(param.getBinding().converter().toType())) {
             return param.getValue();
         }
-        if (JSONB.class.isAssignableFrom(param.getBinding().converter().toType())) {
-            return param.getValue().toString();
-        }
-        if (JSON.class.isAssignableFrom(param.getBinding().converter().toType())) {
-            return param.getValue().toString();
+        if (JSONB.class.isAssignableFrom(param.getBinding().converter().fromType()) ||
+                JSON.class.isAssignableFrom(param.getBinding().converter().fromType())) {
+            return param.getBinding().converter().to(param.getValue()).toString();
         }
         if (byte[].class.isAssignableFrom(param.getBinding().converter().fromType())) { // jooq treats BINARY types as byte[] but the reactive client expects a Buffer to write to blobs
             byte[] bytes = (byte[]) param.getBinding().converter().to(param.getValue());

--- a/vertx-jooq-shared/src/main/java/io/github/jklingsporn/vertx/jooq/shared/internal/AbstractVertxDAO.java
+++ b/vertx-jooq-shared/src/main/java/io/github/jklingsporn/vertx/jooq/shared/internal/AbstractVertxDAO.java
@@ -189,7 +189,7 @@ public abstract class AbstractVertxDAO<R extends UpdatableRecord<R>, P, T, FIND_
     }
 
     @SuppressWarnings("unchecked")
-    protected Condition equalKeys(Collection<T> ids){
+    public Condition equalKeys(Collection<T> ids){
         UniqueKey<?> uk = getTable().getPrimaryKey();
         Objects.requireNonNull(uk,()->"No primary key");
         /**


### PR DESCRIPTION
Just been testing the release 5.0.0 branch and it is working out great so far - thanks for all the work :) With these fixes I have jsonb support working out of the box so far without any forcedtypes. 

Technically the `JsonObject` check is not necessary for default support but from my testing it would be necessary if one wants to use `JsonObject` instead.

This fixes https://github.com/jklingsporn/vertx-jooq/issues/118