### PR TITLE
fix(enum): Fix NPE if we try to parse an enum with a null value

### DIFF
--- a/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/AbstractReactiveQueryExecutor.java
+++ b/vertx-jooq-shared-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/shared/reactive/AbstractReactiveQueryExecutor.java
@@ -44,6 +44,9 @@ public abstract class AbstractReactiveQueryExecutor extends AbstractQueryExecuto
          * DataTypes. Workaround is to convert them to string before adding to the Tuple.
          */
         if (Enum.class.isAssignableFrom(param.getBinding().converter().toType())) {
+            if (param.getValue() == null) {
+                return null;
+            }
             return param.getValue().toString();
         }
         if (byte[].class.isAssignableFrom(param.getBinding().converter().fromType())) { // jooq treats BINARY types as byte[] but the reactive client expects a Buffer to write to blobs


### PR DESCRIPTION
I wanted to save a Pojo with an enum to null.