### PR TITLE
Close connection on rollback

### DIFF
--- a/vertx-jooq-classic-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/classic/reactivepg/ReactiveClassicGenericQueryExecutor.java
+++ b/vertx-jooq-classic-reactive/src/main/java/io/github/jklingsporn/vertx/jooq/classic/reactivepg/ReactiveClassicGenericQueryExecutor.java
@@ -100,7 +100,7 @@ public class ReactiveClassicGenericQueryExecutor extends AbstractReactiveQueryEx
         if(transaction==null){
             return Future.failedFuture(new IllegalStateException("Not in transaction"));
         }
-        return transaction.commit().compose(v->delegate.close());
+        return transaction.commit().eventually(v->delegate.close());
     }
 
     /**


### PR DESCRIPTION
Currently on rollback the connection stays open, this should be closed on both success and failure.