### PR TITLE
Fix #206: handle "null" string as null, for postgres json

### DIFF
--- a/vertx-jooq-shared/src/main/java/io/github/jklingsporn/vertx/jooq/shared/postgres/JSONToJsonObjectConverter.java
+++ b/vertx-jooq-shared/src/main/java/io/github/jklingsporn/vertx/jooq/shared/postgres/JSONToJsonObjectConverter.java
@@ -18,7 +18,7 @@ public class JSONToJsonObjectConverter implements PgConverter<JsonObject, JSON, 
 
     @Override
     public JsonObject from(JSON t) {
-        return t == null || t.data() == null ? null : new JsonObject(t.data());
+        return t == null || t.data() == null || t.data().equals("null") ? null : new JsonObject(t.data());
     }
 
     @Override


### PR DESCRIPTION
It seems that somewhere in the postgres/jooq stack, the null json value is coming back as the string literal 'null', which is breaking the vertx JsonObject. By checking for this, all seems well again.

There seems to be no existing test code for this postgres-specific JSONToJsonObjectConverter, so I haven't added any to go with this.