### PR TITLE
Do not update fields that haven't changed

### DIFF
--- a/vertx-jooq-shared/src/main/java/io/github/jklingsporn/vertx/jooq/shared/internal/AbstractVertxDAO.java
+++ b/vertx-jooq-shared/src/main/java/io/github/jklingsporn/vertx/jooq/shared/internal/AbstractVertxDAO.java
@@ -60,7 +60,7 @@ public abstract class AbstractVertxDAO<R extends UpdatableRecord<R>, P, T, FIND_
                 where = where.and(((TableField<R,Object>)tableField).eq(rec.get(tableField)));
             }
             Map<String, Object> valuesToUpdate =
-                    Arrays.stream(rec.fields())
+                    Arrays.stream(rec.fields()).filter(f -> rec.changed(f))
                             .collect(HashMap::new, (m, f) -> m.put(f.getName(), f.getValue(rec)), HashMap::putAll);
             return dslContext
                     .update(getTable())


### PR DESCRIPTION
Currently "unchanged" fields are just the primary key fields that get reset a few LoCs above.

In the future, one may have a logic to detect actual changes and create records where the POJO fields that haven't changed are correctly reset as well.

This may be very useful to support MySQL/MariaDB `TIMESTAMP` fields with an `ON UPDATE CURRENT_TIMESTAMP()` feature, which are currently being overwritten by the old value in the POJO and there for are broken with vertx-jooq.